### PR TITLE
Improve Docker workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Ignore data artifacts and experiment logs
+/data
+/mlruns
+/models
+/metrics
+.notebooks
+
+.git
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# DVC artifacts
+.dvc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+up:
+	docker compose -f docker/docker-compose.yml up --build -d
+
+pipeline:
+	docker compose -f docker/docker-compose.yml exec credit-risk-app dvc pull
+	docker compose -f docker/docker-compose.yml exec credit-risk-app dvc repro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     build:
       context: ..                      # sigue usando la raíz
       dockerfile: docker/Dockerfile    # aquí le dices dónde está
+    env_file:
+      - ../.env
     depends_on:
       - spark-master
       - mlflow

--- a/src/api.py
+++ b/src/api.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 import mlflow.spark
+from pyspark.sql import SparkSession
 
 app = FastAPI()
 model = None
@@ -20,7 +21,7 @@ def predict(features: dict):
         return {"error": "model not loaded"}
     import pandas as pd
     df = pd.DataFrame([features])
-    spark = mlflow.spark.get_active_session() or mlflow.spark.SparkSession.builder.getOrCreate()
+    spark = mlflow.spark.get_active_session() or SparkSession.builder.getOrCreate()
     sdf = spark.createDataFrame(df)
     preds = model.transform(sdf).toPandas()
     return {"prediction": preds['prediction'].iloc[0]}


### PR DESCRIPTION
## Summary
- ensure Spark session builder is imported in the FastAPI app
- pass environment variables into Docker compose
- add `.dockerignore` to skip heavy folders
- add `Makefile` helpers for docker compose and dvc pipeline

## Testing
- `pytest -q`