### PR TITLE
Fix python imports in pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ up:
 	docker compose -f docker/docker-compose.yml up --build -d
 
 pipeline:
-	docker compose -f docker/docker-compose.yml exec credit-risk-app \
-		bash -c "python src/agents/fetch.py && \
-			python src/agents/prep.py && \
-			python src/agents/split.py && \
-			python src/agents/train_sup.py && \
-			python src/agents/train_unsup.py && \
-			python src/agents/evaluate.py && \
-			python src/agents/register.py"
+        docker compose -f docker/docker-compose.yml exec credit-risk-app \
+                bash -c "python -m src.agents.fetch && \
+                        python -m src.agents.prep && \
+                        python -m src.agents.split && \
+                        python -m src.agents.train_sup && \
+                        python -m src.agents.train_unsup && \
+                        python -m src.agents.evaluate && \
+                        python -m src.agents.register"
 # ─────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -126,14 +126,15 @@ Consulte `AGENTS.md` para una descripción detallada de cada agente y de la arqu
 2. Instalar las dependencias con `pip install -r requirements.txt`.
 3. Copiar `\.env.example` a `\.env` y completar las credenciales de Kaggle.
 4. Levantar los servicios locales con `docker compose up -d`.
+   La imagen Docker instala Java 11, requisito de PySpark, y exporta `JAVA_HOME`.
 5. Ejecutar secuencialmente:
-   `python src/agents/fetch.py`,
-   `python src/agents/prep.py`,
-   `python src/agents/split.py`,
-   `python src/agents/train_sup.py`,
-   `python src/agents/train_unsup.py`,
-   `python src/agents/evaluate.py`,
-   `python src/agents/register.py`.
+   `python -m src.agents.fetch`,
+   `python -m src.agents.prep`,
+   `python -m src.agents.split`,
+   `python -m src.agents.train_sup`,
+   `python -m src.agents.train_unsup`,
+   `python -m src.agents.evaluate`,
+   `python -m src.agents.register`.
 6. Acceder a la interfaz de MLflow en `http://localhost:5000` y a la API de predicción en `http://localhost:8000/predict`.
 7. Para verificar el código ejecutar `pytest`.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,15 @@
 FROM python:3.11-slim
+
+# Install Java and procps for PySpark
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openjdk-11-jdk-headless procps \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+
 CMD ["uvicorn", "src.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   spark-master:
     image: bitnami/spark:latest


### PR DESCRIPTION
## Summary
- run pipeline agents using `-m` module syntax so imports work
- install Java in the Dockerfile so PySpark runs
- document Java setup in quickstart guide
- remove deprecated version field from compose file

## Testing
- `pytest -q`
