### PR TITLE
Fix tests and provide Activity 3 summary

### DIFF
--- a/Actividad3_00000000.md
+++ b/Actividad3_00000000.md
@@ -1,0 +1,21 @@
+# Actividad 3 - Aprendizaje Supervisado y No Supervisado
+
+Este documento resume los pasos ejecutados para cumplir con la actividad.
+
+## 1. Introducción
+Se explican de forma concisa los conceptos de **aprendizaje supervisado** y **no supervisado** y se enumeran los algoritmos representativos disponibles en PySpark que se usaron durante la práctica.
+
+## 2. Selección de los datos
+Se obtuvo una muestra estratificada del dataset de LendingClub siguiendo el plan de muestreo del proyecto. El código correspondiente se encuentra en `src/agents/prep.py` y genera el archivo `data/processed/sample_M.parquet`.
+
+## 3. Preparación de los datos
+El agente de preparación corrige valores nulos, aplica *winsorización* para atípicos y realiza `type casting`. El resultado se almacena en `data/processed/M.parquet`.
+
+## 4. Preparación del conjunto de entrenamiento y prueba
+El agente `src/agents/split.py` divide la muestra M en **80 % entrenamiento** y **20 % prueba** de forma estratificada por `grade` y `loan_status`.
+
+## 5. Modelos de aprendizaje
+- **Supervisado:** `src/agents/train_sup.py` entrena RandomForest, GBT y MLP sobre la etiqueta `default_flag`.
+- **No supervisado:** `src/agents/train_unsup.py` realiza agrupamiento mediante K-Means y GaussianMixture.
+
+Las métricas y modelos se registran automáticamente en MLflow para su posterior análisis.

--- a/tests/test_balancing.py
+++ b/tests/test_balancing.py
@@ -10,16 +10,26 @@ from src.utils.spark import get_spark
 from src.utils.balancing import compute_class_weights, add_weight_column
 
 
-def test_compute_class_weights():
+@pytest.fixture(scope="session")
+def spark_session():
     spark = get_spark("test-balance")
+    yield spark
+    try:
+        spark.stop()
+    except Exception:
+        pass
+
+
+def test_compute_class_weights(spark_session):
+    spark = spark_session
     df = spark.createDataFrame([(0,), (0,), (0,), (1,)], ["label"])
     weights = compute_class_weights(df, "label")
     assert pytest.approx(weights[0]) == 4 / (2 * 3)
     assert pytest.approx(weights[1]) == 4 / (2 * 1)
 
 
-def test_add_weight_column():
-    spark = get_spark("test-balance")
+def test_add_weight_column(spark_session):
+    spark = spark_session
     df = spark.createDataFrame([(0,), (0,), (0,), (1,)], ["label"])
     df_w = add_weight_column(df, "label")
     rows = {r["label"]: r["weight"] for r in df_w.groupBy("label", "weight").count().collect()}

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -9,8 +9,21 @@ from src.utils.spark import get_spark
 from src.agents.split import stratified_split
 
 
-def test_stratified_split_counts():
+import pytest
+
+
+@pytest.fixture(scope="session")
+def spark_session():
     spark = get_spark("test-split")
+    yield spark
+    try:
+        spark.stop()
+    except Exception:
+        pass
+
+
+def test_stratified_split_counts(spark_session):
+    spark = spark_session
     rows = []
     for i in range(10):
         rows.append(("A", "Good", i))


### PR DESCRIPTION
## Summary
- make Spark fixtures stop gracefully in tests
- update test functions to reuse the shared Spark session
- add `Actividad3_00000000.md` with summary of the activity steps

## Testing
- `pytest -q`