### PR TITLE
Align Act4 notebook with preprocessing pipeline

### DIFF
--- a/notebooks/Actividad4_Metricas.ipynb
+++ b/notebooks/Actividad4_Metricas.ipynb
@@ -1,1 +1,154 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": "# Actividad 4: M\u00e9tricas de Calidad de Resultados\n\nEste notebook reproduce el pipeline descrito para generar una muestra de datos, dividirla en conjuntos de entrenamiento y prueba, entrenar modelos supervisados y no supervisados, y evaluar la calidad de los resultados."}, {"cell_type": "markdown", "metadata": {}, "source": "## Construcci\u00f3n de la muestra M\nUsamos PySpark para crear una muestra representativa `M` de la poblaci\u00f3n original `P` y particionarla siguiendo la estrategia de la actividad previa."}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": "from pyspark.sql import SparkSession\n\nspark = SparkSession.builder.appName('Actividad4').getOrCreate()\n\n# Cargar dataset completo\ndf = spark.read.csv('poblacion_completa.csv', header=True, inferSchema=True)\nprint('Total de instancias en P:', df.count())\n\n# Muestreo estratificado por la columna 'label'\nclases = [row[0] for row in df.select('label').distinct().collect()]\nfracciones = {cl: 0.1 for cl in clases}\nM_df = df.sampleBy('label', fractions=fracciones, seed=42)\nprint('Total de instancias en muestra M:', M_df.count())\n\n# Particionar M por clase\nparticiones = {cl: M_df.filter(M_df.label == cl) for cl in clases}"}, {"cell_type": "markdown", "metadata": {}, "source": "## Construcci\u00f3n Train/Test\nSepara cada partici\u00f3n `M_i` en conjuntos de entrenamiento y prueba de manera estratificada (80/20)."}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": "fracciones_train = {cl: 0.8 for cl in clases}\ntrain_df = M_df.sampleBy('label', fractions=fracciones_train, seed=42)\ntest_df = M_df.subtract(train_df)\nprint('Instancias en Train:', train_df.count())\nprint('Instancias en Test:', test_df.count())"}, {"cell_type": "markdown", "metadata": {}, "source": "## M\u00e9tricas de evaluaci\u00f3n\nUsaremos exactitud y precisi\u00f3n para el modelo supervisado, y silhouette y WSSSE para el modelo no supervisado."}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": "from pyspark.ml.evaluation import ClusteringEvaluator\n\n# Exactitud\ndef calcular_exactitud(pred_df):\n    aciertos = pred_df.filter(pred_df.label == pred_df.prediction).count()\n    return aciertos / pred_df.count()\n\n# Precisi\u00f3n binaria\ndef calcular_precision(pred_df, clase_positiva=1):\n    tp = pred_df.filter((pred_df.label == clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    fp = pred_df.filter((pred_df.label != clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    return tp / (tp + fp) if (tp + fp) != 0 else 0.0\n\nsilhouette_evaluator = ClusteringEvaluator(featuresCol='features', predictionCol='prediction', metricName='silhouette', distanceMeasure='squaredEuclidean')"}, {"cell_type": "markdown", "metadata": {}, "source": "## Entrenamiento de modelos\nEntrenaremos un \u00e1rbol de decisi\u00f3n y un modelo K-Means."}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": "from pyspark.ml.feature import VectorAssembler\nfrom pyspark.ml.classification import DecisionTreeClassifier\nfrom pyspark.ml.clustering import KMeans\n\nfeature_cols = [c for c in train_df.columns if c != 'label']\nassembler = VectorAssembler(inputCols=feature_cols, outputCol='features')\ntrain_data = assembler.transform(train_df).select('features','label')\ntest_data = assembler.transform(test_df).select('features','label')\n\ndt = DecisionTreeClassifier(labelCol='label', featuresCol='features', maxDepth=5, seed=42)\ndt_model = dt.fit(train_data)\npredicciones_dt = dt_model.transform(test_data)\n\nM_data = assembler.transform(M_df).select('features')\nkmeans = KMeans(featuresCol='features', k=4, seed=1)\nkmeans_model = kmeans.fit(M_data)\npredicciones_cluster = kmeans_model.transform(M_data)\nwssse = kmeans_model.summary.trainingCost"}, {"cell_type": "markdown", "metadata": {}, "source": "## Evaluaci\u00f3n y an\u00e1lisis de resultados"}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": "exactitud_dt = calcular_exactitud(predicciones_dt)\nprecision_dt = calcular_precision(predicciones_dt, clase_positiva=1)\nprint(f'Exactitud del \u00e1rbol: {exactitud_dt:.4f}')\nprint(f'Precisi\u00f3n del \u00e1rbol: {precision_dt:.4f}')\n\nsilhouette = silhouette_evaluator.evaluate(predicciones_cluster)\nprint(f'Silhouette del clustering: {silhouette}')\nprint(f'WSSSE del KMeans: {wssse}')"}, {"cell_type": "markdown", "metadata": {}, "source": "El \u00e1rbol de decisi\u00f3n obtuvo una exactitud y precisi\u00f3n altas sobre el conjunto de prueba, mientras que el KMeans logr\u00f3 un silhouette moderado. Estos valores permiten comparar la efectividad de los modelos supervisados y no supervisados."}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.8"}}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Actividad 4: M\u00e9tricas de Calidad de Resultados\n\nEste notebook reproduce el pipeline descrito para generar una muestra de datos, dividirla en conjuntos de entrenamiento y prueba, entrenar modelos supervisados y no supervisados, y evaluar la calidad de los resultados.  \nEl dataset `P` proviene de LendingClub y se descarg\u00f3 de Kaggle (~2.9 millones de pr\u00e9stamos).  \nReutilizamos el archivo `data/processed/M_full.parquet` generado en la Actividad 3."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Construcci\u00f3n de la muestra M\nUsamos PySpark para crear una muestra representativa `M` de la poblaci\u00f3n original `P` y particionarla siguiendo la estrategia de la actividad previa."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path",
+    "import sys",
+    "from pyspark.sql import functions as F",
+    "",
+    "sys.path.append('../src')",
+    "from src.utils.spark import get_spark",
+    "",
+    "spark = get_spark('Actividad4')",
+    "",
+    "data_path = Path('../data/processed/M_full.parquet')",
+    "if data_path.exists():",
+    "    df = spark.read.parquet(str(data_path))",
+    "else:",
+    "    df = spark.read.csv('poblacion_completa.csv', header=True, inferSchema=True)",
+    "print('Total de instancias en P:', df.count())",
+    "",
+    "df = df.withColumnRenamed('default_flag', 'label')",
+    "# Muestreo estratificado por grade y loan_status",
+    "df = df.withColumn('estrato', F.concat_ws('_', 'grade', 'loan_status'))",
+    "estratos = [r[0] for r in df.select('estrato').distinct().collect()]",
+    "fracciones = {e: 0.1 for e in estratos}",
+    "M_df = df.sampleBy('estrato', fractions=fracciones, seed=42).drop('estrato')",
+    "print('Total de instancias en muestra M:', M_df.count())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Construcci\u00f3n Train/Test",
+    "Dividimos la muestra `M` en conjuntos de entrenamiento y prueba manteniendo la estratificaci\u00f3n por `grade` y `loan_status` como en la Actividad 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from src.agents.split import stratified_split",
+    "",
+    "train_df, test_df = stratified_split(M_df, ['grade', 'loan_status'], test_frac=0.2, seed=42)",
+    "print('Instancias en Train:', train_df.count())",
+    "print('Instancias en Test:', test_df.count())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## M\u00e9tricas de evaluaci\u00f3n\nUsaremos exactitud y precisi\u00f3n para el modelo supervisado, y silhouette y WSSSE para el modelo no supervisado."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from pyspark.ml.evaluation import ClusteringEvaluator\n\n# Exactitud\ndef calcular_exactitud(pred_df):\n    aciertos = pred_df.filter(pred_df.label == pred_df.prediction).count()\n    return aciertos / pred_df.count()\n\n# Precisi\u00f3n binaria\ndef calcular_precision(pred_df, clase_positiva=1):\n    tp = pred_df.filter((pred_df.label == clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    fp = pred_df.filter((pred_df.label != clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    return tp / (tp + fp) if (tp + fp) != 0 else 0.0\n\nsilhouette_evaluator = ClusteringEvaluator(featuresCol='features', predictionCol='prediction', metricName='silhouette', distanceMeasure='squaredEuclidean')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Entrenamiento de modelos\nEntrenaremos un \u00e1rbol de decisi\u00f3n y un modelo K-Means."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pyspark.ml.feature import StringIndexer, OneHotEncoder, VectorAssembler",
+    "from pyspark.ml.classification import DecisionTreeClassifier",
+    "from pyspark.ml.clustering import KMeans",
+    "from pyspark.ml import Pipeline",
+    "",
+    "categoricas = ['term','grade','emp_length','home_ownership','verification_status','purpose']",
+    "indexers = [StringIndexer(inputCol=c, outputCol=c+'_idx', handleInvalid='keep') for c in categoricas]",
+    "encoders = [OneHotEncoder(inputCol=c+'_idx', outputCol=c+'_oh') for c in categoricas]",
+    "numericas = ['loan_amnt','int_rate','installment','annual_inc','dti','revol_util','loan_to_income','credit_age']",
+    "assembler = VectorAssembler(inputCols=[c+'_oh' for c in categoricas] + numericas, outputCol='features')",
+    "",
+    "pipeline = Pipeline(stages=indexers + encoders + [assembler])",
+    "prep_model = pipeline.fit(train_df)",
+    "train_data = prep_model.transform(train_df).select('features','label')",
+    "test_data = prep_model.transform(test_df).select('features','label')",
+    "",
+    "dt = DecisionTreeClassifier(labelCol='label', featuresCol='features', maxDepth=5, seed=42)",
+    "dt_model = dt.fit(train_data)",
+    "predicciones_dt = dt_model.transform(test_data)",
+    "",
+    "M_data = prep_model.transform(M_df).select('features')",
+    "kmeans = KMeans(featuresCol='features', k=4, seed=1)",
+    "kmeans_model = kmeans.fit(M_data)",
+    "predicciones_cluster = kmeans_model.transform(M_data)",
+    "wssse = kmeans_model.summary.trainingCost"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Evaluaci\u00f3n y an\u00e1lisis de resultados"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "exactitud_dt = calcular_exactitud(predicciones_dt)\nprecision_dt = calcular_precision(predicciones_dt, clase_positiva=1)\nprint(f'Exactitud del \u00e1rbol: {exactitud_dt:.4f}')\nprint(f'Precisi\u00f3n del \u00e1rbol: {precision_dt:.4f}')\n\nsilhouette = silhouette_evaluator.evaluate(predicciones_cluster)\nprint(f'Silhouette del clustering: {silhouette}')\nprint(f'WSSSE del KMeans: {wssse}')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "El \u00e1rbol de decisi\u00f3n obtuvo una exactitud y precisi\u00f3n altas sobre el conjunto de prueba, mientras que el KMeans logr\u00f3 un silhouette moderado. Estos valores permiten comparar la efectividad de los modelos supervisados y no supervisados."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- document that the LendingClub dataset comes from Kaggle and reuse M_full.parquet
- load the processed data, rename `default_flag`, and sample by grade and status
- split train/test using `stratified_split`
- encode categorical variables before training models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845145d4678832da3508b5c65a0c95d