### PR TITLE
Extiende notebook Actividad 4

### DIFF
--- a/notebooks/Actividad4_Metricas.ipynb
+++ b/notebooks/Actividad4_Metricas.ipynb
@@ -3,12 +3,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Actividad 4: M\u00e9tricas de Calidad de Resultados\n\nEste notebook reproduce el pipeline descrito para generar una muestra de datos, dividirla en conjuntos de entrenamiento y prueba, entrenar modelos supervisados y no supervisados, y evaluar la calidad de los resultados.  \nEl dataset `P` proviene de LendingClub y se descarg\u00f3 de Kaggle (~2.9 millones de pr\u00e9stamos).  \nReutilizamos el archivo `data/processed/M_full.parquet` generado en la Actividad 3."
+   "source": "# Actividad 4: Métricas de Calidad de Resultados\n\nEste notebook reproduce el pipeline descrito para generar una muestra de datos, dividirla en conjuntos de entrenamiento y prueba, entrenar modelos supervisados y no supervisados, y evaluar la calidad de los resultados.  \nEl dataset `P` proviene de LendingClub y se descargó de Kaggle (~2.9 millones de préstamos).  \nReutilizamos el archivo `data/processed/M_full.parquet` generado en la Actividad 3."
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Construcci\u00f3n de la muestra M\nUsamos PySpark para crear una muestra representativa `M` de la poblaci\u00f3n original `P` y particionarla siguiendo la estrategia de la actividad previa."
+   "source": "## Construcción de la muestra M\nUsamos PySpark para crear una muestra representativa `M` de la población original `P` y particionarla siguiendo la estrategia de la actividad previa."
   },
   {
    "cell_type": "code",
@@ -45,8 +45,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Construcci\u00f3n Train/Test",
-    "Dividimos la muestra `M` en conjuntos de entrenamiento y prueba manteniendo la estratificaci\u00f3n por `grade` y `loan_status` como en la Actividad 3."
+    "# Construcción Train/Test",
+    "Dividimos la muestra `M` en conjuntos de entrenamiento y prueba manteniendo la estratificación por `grade` y `loan_status` como en la Actividad 3."
    ]
   },
   {
@@ -65,19 +65,19 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## M\u00e9tricas de evaluaci\u00f3n\nUsaremos exactitud y precisi\u00f3n para el modelo supervisado, y silhouette y WSSSE para el modelo no supervisado."
+   "source": "## Métricas de evaluación\nUsaremos exactitud y precisión para el modelo supervisado, y silhouette y WSSSE para el modelo no supervisado."
   },
   {
    "cell_type": "code",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "from pyspark.ml.evaluation import ClusteringEvaluator\n\n# Exactitud\ndef calcular_exactitud(pred_df):\n    aciertos = pred_df.filter(pred_df.label == pred_df.prediction).count()\n    return aciertos / pred_df.count()\n\n# Precisi\u00f3n binaria\ndef calcular_precision(pred_df, clase_positiva=1):\n    tp = pred_df.filter((pred_df.label == clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    fp = pred_df.filter((pred_df.label != clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    return tp / (tp + fp) if (tp + fp) != 0 else 0.0\n\nsilhouette_evaluator = ClusteringEvaluator(featuresCol='features', predictionCol='prediction', metricName='silhouette', distanceMeasure='squaredEuclidean')"
+   "source": "from pyspark.ml.evaluation import ClusteringEvaluator\n\n# Exactitud\ndef calcular_exactitud(pred_df):\n    aciertos = pred_df.filter(pred_df.label == pred_df.prediction).count()\n    return aciertos / pred_df.count()\n\n# Precisión binaria\ndef calcular_precision(pred_df, clase_positiva=1):\n    tp = pred_df.filter((pred_df.label == clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    fp = pred_df.filter((pred_df.label != clase_positiva) & (pred_df.prediction == clase_positiva)).count()\n    return tp / (tp + fp) if (tp + fp) != 0 else 0.0\n\nsilhouette_evaluator = ClusteringEvaluator(featuresCol='features', predictionCol='prediction', metricName='silhouette', distanceMeasure='squaredEuclidean')"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Entrenamiento de modelos\nEntrenaremos un \u00e1rbol de decisi\u00f3n y un modelo K-Means."
+   "source": "## Entrenamiento de modelos\nEntrenaremos un árbol de decisión y un modelo K-Means."
   },
   {
    "cell_type": "code",
@@ -115,29 +115,29 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Evaluaci\u00f3n y an\u00e1lisis de resultados"
+   "source": "## Evaluación y análisis de resultados"
   },
   {
    "cell_type": "code",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "exactitud_dt = calcular_exactitud(predicciones_dt)\nprecision_dt = calcular_precision(predicciones_dt, clase_positiva=1)\nprint(f'Exactitud del \u00e1rbol: {exactitud_dt:.4f}')\nprint(f'Precisi\u00f3n del \u00e1rbol: {precision_dt:.4f}')\n\nsilhouette = silhouette_evaluator.evaluate(predicciones_cluster)\nprint(f'Silhouette del clustering: {silhouette}')\nprint(f'WSSSE del KMeans: {wssse}')"
+   "source": "exactitud_dt = calcular_exactitud(predicciones_dt)\nprecision_dt = calcular_precision(predicciones_dt, clase_positiva=1)\nprint(f'Exactitud del árbol: {exactitud_dt:.4f}')\nprint(f'Precisión del árbol: {precision_dt:.4f}')\n\nsilhouette = silhouette_evaluator.evaluate(predicciones_cluster)\nprint(f'Silhouette del clustering: {silhouette}')\nprint(f'WSSSE del KMeans: {wssse}')"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "El \u00e1rbol de decisi\u00f3n obtuvo una exactitud y precisi\u00f3n altas sobre el conjunto de prueba, mientras que el KMeans logr\u00f3 un silhouette moderado. Estos valores permiten comparar la efectividad de los modelos supervisados y no supervisados."
+   "source": "El árbol de decisión obtuvo una exactitud y precisión altas sobre el conjunto de prueba, mientras que el KMeans logró un silhouette moderado. Estos valores permiten comparar la efectividad de los modelos supervisados y no supervisados."
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Pipeline completo con agentes\nA continuaci\u00f3n se resumen los scripts ubicados en `../src/agents` que automatizan el flujo de datos y modelos."
+   "source": "## Pipeline completo con agentes\nA continuación se resumen los scripts ubicados en `../src/agents` que automatizan el flujo de datos y modelos."
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "- `fetch.py`: descarga el dataset crudo desde Kaggle.\n- `prep.py`: limpia los datos y genera el conjunto procesado.\n- `split.py`: crea las particiones de entrenamiento y prueba de forma estratificada.\n- `train_sup.py`: entrena modelos supervisados y registra m\u00e9tricas en MLflow.\n- `train_unsup.py`: entrena un modelo de clustering KMeans.\n- `evaluate.py`: eval\u00faa el mejor modelo supervisado sobre el conjunto de prueba.\n- `register.py`: registra la mejor corrida en el Model Registry de MLflow."
+   "source": "- `fetch.py`: descarga el dataset crudo desde Kaggle.\n- `prep.py`: limpia los datos y genera el conjunto procesado.\n- `split.py`: crea las particiones de entrenamiento y prueba de forma estratificada.\n- `train_sup.py`: entrena modelos supervisados y registra métricas en MLflow.\n- `train_unsup.py`: entrena un modelo de clustering KMeans.\n- `evaluate.py`: evalúa el mejor modelo supervisado sobre el conjunto de prueba.\n- `register.py`: registra la mejor corrida en el Model Registry de MLflow."
   },
   {
    "cell_type": "code",
@@ -145,6 +145,90 @@
    "execution_count": null,
    "outputs": [],
    "source": "# Ejecutar paso a paso el pipeline\n# !python ../src/agents/fetch.py\n# !python ../src/agents/prep.py\n# !python ../src/agents/split.py\n# !python ../src/agents/train_sup.py\n# !python ../src/agents/train_unsup.py\n# !python ../src/agents/evaluate.py\n# !python ../src/agents/register.py"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Entrenamiento de modelos adicionales\nA continuación se entrenan modelos Random Forest, GBT y MLP para comparar su desempeño utilizando AUC."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from pyspark.ml.classification import RandomForestClassifier, GBTClassifier, MultilayerPerceptronClassifier\nfrom pyspark.ml.evaluation import BinaryClassificationEvaluator\n\nrf = RandomForestClassifier(labelCol='label', featuresCol='features', numTrees=50, maxDepth=5, seed=42)\ngbt = GBTClassifier(labelCol='label', featuresCol='features', maxIter=50, maxDepth=5, seed=42)\nmlp = MultilayerPerceptronClassifier(labelCol='label', featuresCol='features', layers=[len(train_data.first()['features']), 20, 2], seed=42)\n\nrf_model = rf.fit(train_data)\ngbt_model = gbt.fit(train_data)\nmlp_model = mlp.fit(train_data)\n\npred_rf = rf_model.transform(test_data)\npred_gbt = gbt_model.transform(test_data)\npred_mlp = mlp_model.transform(test_data)\n\nevaluator = BinaryClassificationEvaluator(labelCol='label', metricName='areaUnderROC')\nauc_dt = evaluator.evaluate(predicciones_dt)\nauc_rf = evaluator.evaluate(pred_rf)\nauc_gbt = evaluator.evaluate(pred_gbt)\nauc_mlp = evaluator.evaluate(pred_mlp)\nprint(f'AUC Decision Tree: {auc_dt:.3f}')\nprint(f'AUC Random Forest: {auc_rf:.3f}')\nprint(f'AUC GBT: {auc_gbt:.3f}')\nprint(f'AUC Multilayer Perceptron: {auc_mlp:.3f}')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Curvas de aprendizaje\nSe evalúa cómo varía el AUC usando distintos tamaños de entrenamiento."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import matplotlib.pyplot as plt\nfractions=[0.2,0.4,0.6,0.8,1.0]\nauc_scores=[]\nfor frac in fractions:\n    subset=train_df.sample(withReplacement=False,fraction=frac,seed=42)\n    subset_data=prep_model.transform(subset).select('features','label')\n    model_temp=RandomForestClassifier(labelCol='label',featuresCol='features',numTrees=50,maxDepth=5,seed=42)\n    model_fit=model_temp.fit(subset_data)\n    pred_temp=model_fit.transform(test_data)\n    auc=evaluator.evaluate(pred_temp)\n    auc_scores.append(auc)\nplt.figure(figsize=(6,4))\nplt.plot([f*100 for f in fractions],auc_scores,marker='o')\nplt.xlabel('Porcentaje del conjunto de entrenamiento')\nplt.ylabel('AUC en conjunto de prueba')\nplt.title('Curva de aprendizaje - Random Forest')\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Integración con MLflow\nLos experimentos de entrenamiento se registran usando MLflow para facilitar su comparación."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import mlflow, mlflow.spark\nwith mlflow.start_run(run_name='RandomForest'):\n    mlflow.log_param('model_type','RandomForestClassifier')\n    mlflow.log_param('numTrees',rf.getNumTrees())\n    mlflow.log_param('maxDepth',rf.getOrDefault('maxDepth'))\n    mlflow.log_metric('auc',auc_rf)\n    mlflow.spark.log_model(rf_model,artifact_path='modelo_rf')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Análisis visual de errores\nSe grafica la matriz de confusión y se revisan los falsos positivos y negativos."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import pandas as pd\nfrom sklearn.metrics import confusion_matrix\nimport seaborn as sns\n\ny_true=[int(r['label']) for r in pred_rf.select('label').collect()]\ny_pred=[int(r['prediction']) for r in pred_rf.select('prediction').collect()]\ncm=confusion_matrix(y_true,y_pred,labels=[0,1])\nplt.figure(figsize=(5,4))\nsns.heatmap(cm,annot=True,fmt='d',cmap='Blues',xticklabels=['No default','Default'],yticklabels=['No default','Default'])\nplt.xlabel('Predicción')\nplt.ylabel('Valor real')\nplt.title('Matriz de confusión - Random Forest')\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Análisis visual de clustering\nSe reduce la dimensionalidad con PCA y se grafican los grupos generados por K-Means."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from pyspark.ml.feature import PCA\npca=PCA(k=2,inputCol='features',outputCol='pca_features')\npca_model=pca.fit(M_data)\nM_with_pca=pca_model.transform(predicciones_cluster)\nsample_plot=M_with_pca.sample(withReplacement=False,fraction=0.1,seed=42)\npdf=sample_plot.select('pca_features','prediction').toPandas()\npdf[['PC1','PC2']]=pd.DataFrame(pdf['pca_features'].tolist(),index=pdf.index)\nplt.figure(figsize=(6,5))\nsns.scatterplot(data=pdf,x='PC1',y='PC2',hue='prediction',palette='viridis',alpha=0.7)\nplt.title('Visualización de clusters (PCA 2D)')\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Interpretabilidad básica\nSe muestran las variables más importantes según el modelo Random Forest."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import pandas as pd\nimport numpy as np\nfeature_names=[c+'_oh' for c in categoricas]+numericas\nimportances=rf_model.featureImportances.toArray()\nimp_df=pd.DataFrame({'feature':feature_names,'importance':importances})\nimp_df=imp_df.groupby('feature',as_index=False).agg({'importance':'sum'})\nimp_df=imp_df.sort_values('importance',ascending=False)\nimp_df.head(10)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Reporte final de comparación\nLa siguiente tabla resume las métricas principales obtenidas por cada modelo."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import pandas as pd\ndata={'Modelo':['DecisionTree','RandomForest','GBT','MLP'],\n       'AUC':[auc_dt,auc_rf,auc_gbt,auc_mlp]}\ndf_metrics=pd.DataFrame(data)\ndf_metrics"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- extend `Actividad4_Metricas.ipynb` with new sections for additional models
- include learning curve, MLflow logging and analysis cells
- add clustering visualisation, interpretability and a final metric report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459c99ea94832dab675ce8afd645b0