### PR TITLE
Fix Spark session retrieval in API predict endpoint

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -21,7 +21,7 @@ def predict(features: dict):
         return {"error": "model not loaded"}
     import pandas as pd
     df = pd.DataFrame([features])
-    spark = mlflow.spark.get_active_session() or SparkSession.builder.getOrCreate()
+    spark = SparkSession.getActiveSession() or SparkSession.builder.getOrCreate()
     sdf = spark.createDataFrame(df)
     preds = model.transform(sdf).toPandas()
     return {"prediction": preds['prediction'].iloc[0]}


### PR DESCRIPTION
## Summary
- fetch Spark session using `SparkSession.getActiveSession()` for prediction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465eb51db0832d8916ad5819c3f42d