### PR TITLE
Sanitize Kaggle credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-KAGGLE_USERNAME=hctorralperazaalavez
-KAGGLE_KEY=52a10288db145ff2baf3c9d97c9ea34b
+KAGGLE_USERNAME=YOUR_KAGGLE_USERNAME
+KAGGLE_KEY=YOUR_KAGGLE_KEY
+# Provide your Kaggle credentials above
 # Replace with the actual dataset ID if different
 KAGGLE_DATASET=hctorralperazaalavez/loan-status-2007-2020q3
 KAGGLE_FILE=Loan_status_2007-2020Q3.gzip


### PR DESCRIPTION
## Summary
- replace Kaggle credentials in `.env.example` with placeholder values
- add comment instructing users to supply their own credentials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68465eb4755c832d92523447dba3ff9b