### PR TITLE
Update mlflow-spark version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV PATH="$JAVA_HOME/bin:$PATH"
 ENV PYTHONPATH=/app
-ENV MLFLOW_SPARK_VERSION=3.5.1
+ENV MLFLOW_SPARK_VERSION=2.13.0
 RUN mkdir -p /opt/spark/jars && \
     wget -q https://repo1.maven.org/maven2/org/mlflow/mlflow-spark/${MLFLOW_SPARK_VERSION}/mlflow-spark-${MLFLOW_SPARK_VERSION}.jar \
     -O /opt/spark/jars/mlflow-spark.jar


### PR DESCRIPTION
## Summary
- update mlflow-spark jar version in Dockerfile to 2.13.0

## Testing
- `pytest -q`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846687f31c0832d9e6355362a0461d8