### PR TITLE
Document pyspark requirement for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Estos pasos deben ejecutarse en el siguiente orden:
 
 Al finalizar, la interfaz de MLflow estará disponible en `http://localhost:5000` y la API de predicción en `http://localhost:8000/predict`.
 
+## Instalación
+
+Este proyecto requiere **Python 3.10+** y las dependencias listadas en
+`requirements.txt`. Para ejecutar las pruebas unitarias es necesario
+contar con `pyspark`. Puede instalarse manualmente mediante
+`pip install pyspark` o bien utilizando el archivo
+`requirements-dev.txt` incluido para facilitar la configuración local.
+
 ## Estructura principal del repositorio
 
 ```text

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development requirements
+-r requirements.txt
+pyspark==3.5.1


### PR DESCRIPTION
## Summary
- mention `pyspark` requirement in README installation notes
- add optional `requirements-dev.txt` for local testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8417cf8c832dad1def95f111f540