### PR TITLE
Update README about pyspark requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,9 @@ Al finalizar, la interfaz de MLflow estará disponible en `http://localhost:5000
 ```
 
 Consulte `AGENTS.md` para una descripción detallada de cada agente y de la arquitectura general.
+
+El archivo `requirements.txt` ya incluye `pyspark`, por lo que no es necesario
+instalarlo de manera independiente. Dicho paquete es necesario tanto para
+ejecutar las pruebas unitarias como para correr los notebooks de la **Actividad
+4**. De forma opcional se provee `requirements-dev.txt` únicamente como un
+archivo de conveniencia para recrear el entorno de desarrollo.


### PR DESCRIPTION
## Summary
- clarify repo structure in README
- explain that pyspark is bundled in requirements.txt and required for tests and Activity 4 notebooks
- mention requirements-dev.txt only as optional convenience

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a87817cb8832d9edc4d1e7cb9cc65